### PR TITLE
Conversation: proposed changes

### DIFF
--- a/migration/src/m0000820_create_conversation.rs
+++ b/migration/src/m0000820_create_conversation.rs
@@ -36,7 +36,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(Conversation::Table)
-                    .name(Conversation::ConverstationUserIdUpdatedAtIdx.to_string())
+                    .name(Indexes::ConversationUserIdUpdatedAtIdx.to_string())
                     .col(Conversation::UserId)
                     .col(Conversation::UpdatedAt)
                     .to_owned(),
@@ -52,7 +52,7 @@ impl MigrationTrait for Migration {
                 Index::drop()
                     .if_exists()
                     .table(Conversation::Table)
-                    .name(Conversation::ConverstationUserIdUpdatedAtIdx.to_string())
+                    .name(Indexes::ConversationUserIdUpdatedAtIdx.to_string())
                     .to_owned(),
             )
             .await?;
@@ -64,11 +64,15 @@ impl MigrationTrait for Migration {
 }
 
 #[derive(DeriveIden)]
+enum Indexes {
+    ConversationUserIdUpdatedAtIdx,
+}
+
+#[derive(DeriveIden)]
 enum Conversation {
     Table,
     Id,
     UserId,
-    ConverstationUserIdUpdatedAtIdx,
     State,
     Seq,
     Summary,

--- a/modules/fundamental/src/ai/service/mod.rs
+++ b/modules/fundamental/src/ai/service/mod.rs
@@ -28,9 +28,8 @@ use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::OnceCell;
 
-use trustify_common::db::{limiter::LimiterTrait, query::Filtering};
+use trustify_common::db::limiter::LimiterTrait;
 
-use trustify_common::db::query::q;
 use trustify_common::db::Database;
 use trustify_common::model::{Paginated, PaginatedResults};
 use trustify_entity::conversation;
@@ -343,7 +342,7 @@ impl AiService {
         id: Uuid,
         connection: &C,
     ) -> Result<Option<conversation::Model>, Error> {
-        let select = conversation::Entity::find().filter(conversation::Column::Id.eq(id));
+        let select = conversation::Entity::find_by_id(id);
 
         Ok(select.one(connection).await?)
     }
@@ -356,7 +355,7 @@ impl AiService {
     ) -> Result<PaginatedResults<conversation::Model>, Error> {
         let limiter = conversation::Entity::find()
             .order_by_desc(conversation::Column::UpdatedAt)
-            .filtering(q(format!("user_id={}", user_id).as_str()))?
+            .filter(conversation::Column::UserId.eq(user_id))
             .limiting(connection, paginated.offset, paginated.limit);
 
         let total = limiter.total().await?;


### PR DESCRIPTION
Re https://github.com/trustification/trustify/pull/1124#pullrequestreview-2534050312, here are the proposed changes in a single PR:

- fixed the typo and moved `ConversationUserIdUpdatedAtIdx` into the `Indexes` enum for consistency with other entities/migrations
- `find_by_id` and `filter` methods usage